### PR TITLE
Critical fix for indexOf polyfill

### DIFF
--- a/src/postfix.js
+++ b/src/postfix.js
@@ -1,9 +1,9 @@
-    
+
     var Mexp=require('./lexer.js');
-	if(!Array.indexOf)
+	if(!(Array.indexOf || Array.prototype.indexOf))
 		Array.prototype.indexOf = function (vItem) {
 			for (var i=0; i < this.length; i++) {
-				if (vItem == this[i]) {
+				if (vItem === this[i]) {
 				return i;
 				}
 			}

--- a/test/index.js
+++ b/test/index.js
@@ -111,3 +111,13 @@ describe('Testing Unit', function () {
 	 assert.equal(a.eval("5*.8"),"4");
   });
 });
+
+describe('Verifying indexOf', function () {
+  it('does not break indexOf', function () {
+    var a = 1;
+    var b = '1';
+    var array = [a, b];
+    assert.equal(array.indexOf(a), 0);
+    assert.equal(array.indexOf(b), 1);
+  });
+});


### PR DESCRIPTION
Discovered in MoOx/reduce-css-calc#13.

The use of double equals is a critical flaw, and the check to see if indexOf needs to be polyfilled was also incorrect leading to it always being used.