### PR TITLE
Fix the repository URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/redhivesoftware/math-expression-evaluator#readme"
+    "url": "https://github.com/redhivesoftware/math-expression-evaluator.git"
   },
   "keywords": [
     "math",


### PR DESCRIPTION
The #readme anchor should not be part of the URL, and the URL should be
the one GitHub itself shows in the "Clone with HTTPS" dialog.